### PR TITLE
Further work to add filter to PanoramaSky

### DIFF
--- a/scene/resources/sky_material.h
+++ b/scene/resources/sky_material.h
@@ -110,8 +110,8 @@ private:
 	Ref<Texture2D> panorama;
 
 	static Mutex shader_mutex;
-	static RID shader;
-	void _update_shader();
+	static RID shader_cache[2];
+	static void _update_shader();
 	mutable bool shader_set = false;
 
 	bool filter = true;


### PR DESCRIPTION
Uses a shader_cache instead of a single shader. The shader_cache is static and is initialized and compiled on the first use of a PanoramaSkyMaterial. So we maintain the benefits of using static initialization, but are able to swap between properties are run time. 

If we add more options then we will want to consider using a hashmap like BaseMaterial instead of a two-element cache.

Please let me know if you have any questions about the below code. I found the best way for me to think through the problem was to actually work through it. In the end it made more sense to PR the code to your repo than to leave the code in changes in a code review. 